### PR TITLE
fix: add missing #include <climits> to demo programs

### DIFF
--- a/notebooks/demos/conditionals/rectangle/main.cpp
+++ b/notebooks/demos/conditionals/rectangle/main.cpp
@@ -22,6 +22,7 @@ Algorithm steps:
 #include <sstream>
 #include <cstdio>
 #include <cassert>
+#include <climits>
 
 using namespace std;
 

--- a/notebooks/demos/loops/rectangle/main.cpp
+++ b/notebooks/demos/loops/rectangle/main.cpp
@@ -22,6 +22,7 @@ Algorithm steps:
 #include <sstream>
 #include <cstdio>
 #include <cassert>
+#include <climits>
 
 using namespace std;
 


### PR DESCRIPTION
## Summary
- Added missing `#include <climits>` to two C++ demo programs that use `INT_MAX` without the proper header.

## Problem
Two demo programs fail to compile because they use `INT_MAX` (from `<climits>`) without including the header:
- `notebooks/demos/conditionals/rectangle/main.cpp`
- `notebooks/demos/loops/rectangle/main.cpp`

Both files use `cin.ignore(INT_MAX, '\n')` to clear the input buffer, but the `<climits>` header was not included.

## Evidence
Compiling either demo with `make` fails with an "INT_MAX was not declared" error.

## Solution
Added `#include <climits>` to the include section of both files, following the existing include style in the codebase.

## Tests / Validation
Ran the following compilation and execution tests:

```bash
cd notebooks/demos/conditionals/rectangle && make clean && make
# Result: ✅ Compiled successfully

cd notebooks/demos/loops/rectangle && make clean && make  
# Result: ✅ Compiled successfully
```

Both programs ran correctly with sample input (length=5, width=3 for rectangle area/perimeter calculation).

## Risk / Compatibility
Minimal risk — adds one standard C++ header include per file. No behavioral changes.

## Notes for maintainers
- This is a build fix, not a logic change
- Both files had the same missing include issue and were fixed in the same commit for efficiency