### PR TITLE
ci: compile C++ demos in GitHub Actions workflow

### DIFF
--- a/.github/workflows/compile-demos.yml
+++ b/.github/workflows/compile-demos.yml
@@ -1,0 +1,55 @@
+name: Compile Demos
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install g++
+      run: |
+        apt-get update
+        apt-get install -y g++
+
+    - name: Compile conditionals/rectangle
+      run: |
+        cd notebooks/demos/conditionals/rectangle
+        g++ -std=c++17 -Wall -o rectangle.exe main.cpp
+
+    - name: Compile loops/rectangle
+      run: |
+        cd notebooks/demos/loops/rectangle
+        g++ -std=c++17 -Wall -o rectangle.exe main.cpp
+
+    - name: Compile pointers/rectangle
+      run: |
+        cd notebooks/demos/pointers/rectangle
+        g++ -std=c++17 -Wall -o rectangle.exe main.cpp
+
+    - name: Compile functions/rectangle
+      run: |
+        cd notebooks/demos/functions/rectangle
+        g++ -std=c++17 -Wall -o rectangle.exe main.cpp
+
+    - name: Compile classes/points
+      run: |
+        cd notebooks/demos/classes/points
+        g++ -std=c++17 -Wall -o point.exe src/main.cpp src/point.cpp
+
+    - name: Compile stdio/demo1
+      run: |
+        cd notebooks/demos/stdio/demo1
+        g++ -std=c++17 -Wall -o demo1.exe main.cpp
+
+    - name: Compile maps/letter_frequency
+      run: |
+        cd notebooks/demos/maps/letter_frequency
+        g++ -std=c++17 -Wall -o letter_frequency.exe main.cpp


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow `.github/workflows/compile-demos.yml` that compiles 7 representative C++ demos on every push and PR.
- Ensures the codebase's demo programs remain compilable and catches build regressions early.

## Problem
The repository had no CI pipeline to verify that C++ demo programs compile correctly. A broken demo (e.g., missing `#include <climits>`) would only be discovered when a contributor or student tries to compile it locally.

## Evidence
Issues #3 (recently merged) fixed a missing `#include <climits>` in two demos — demonstrating that without CI, such issues are only caught by chance.

## Solution
Created a GitHub Actions workflow that:
- Runs on `ubuntu-latest`
- Installs `g++` with `-Wall -std=c++17` flags
- Compiles 7 demos across different topics:
  - `conditionals/rectangle`
  - `loops/rectangle`
  - `pointers/rectangle`
  - `functions/rectangle`
  - `classes/points`
  - `stdio/demo1`
  - `maps/letter_frequency`
- Fails the build if any demo fails to compile

## Tests / Validation
- Verified all 7 demos exist and have Makefiles
- Verified `.gitignore` properly ignores build artifacts (`.o`, `.exe`)

## Risk / Compatibility
Low — CI-only change, no runtime behavior affected. The workflow will fail appropriately if new demos break.

## Notes for maintainers
- 7 demos selected as representative across topics — not all demos (to keep CI runtime reasonable)
- Can be extended to more demos if desired
- Build artifacts are properly ignored by git